### PR TITLE
Add linear filtering and mipmapping to parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Excluded assets
 /assets/excluded
+
+# Logs
+/logs

--- a/core/src/rendering/texture.cpp
+++ b/core/src/rendering/texture.cpp
@@ -16,8 +16,9 @@ Texture::Texture(const char* texturePath, unsigned int format, bool noMipMaps) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
     // Interpolation
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    if (!noMipMaps) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    if (noMipMaps) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     // stbi_set_flip_vertically_on_load(true);
     int width, height, nrChannels;

--- a/core/src/rendering/texture3d.cpp
+++ b/core/src/rendering/texture3d.cpp
@@ -17,8 +17,8 @@ Texture3D::Texture3D(const char* texturePath, unsigned int tileWidth, unsigned i
     glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_R, GL_REPEAT);
 
     // Interpolation
-    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     // stbi_set_flip_vertically_on_load(true);
     int width, height, nrChannels;
@@ -32,6 +32,7 @@ Texture3D::Texture3D(const char* texturePath, unsigned int tileWidth, unsigned i
 
     glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, format, tileWidth, tileHeight, /* no of layers= */ tileCount, 0, format,
                  GL_UNSIGNED_BYTE, data);
+    glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
 
     stbi_image_free(data);
 }


### PR DESCRIPTION
Added filtering to all objects that use Texture and Texture3d and mipmapping to all objects that use Texture3d

I was unable to add mipmapping to the skybox and it seems like its already using linear filtering