### PR TITLE
cool reflections

### DIFF
--- a/core/src/objects/part/basepart.h
+++ b/core/src/objects/part/basepart.h
@@ -83,6 +83,7 @@ public:
     DEF_PROP_CATEGORY(APPEARANCE)
     DEF_PROP Color3 color;
     DEF_PROP float transparency = 0.f;
+    DEF_PROP float reflectance = 0.f;
     
     DEF_PROP_CATEGORY(BEHAVIOR)
     DEF_PROP_(on_update=onUpdated) bool anchored = false;

--- a/core/src/rendering/renderer.cpp
+++ b/core/src/rendering/renderer.cpp
@@ -137,6 +137,7 @@ static void renderPart(std::shared_ptr<BasePart> part) {
     shader->set("normalMatrix", normalMatrix);
     shader->set("texScale", size);
     shader->set("transparency", part->transparency);
+    shader->set("reflectance", part->reflectance);
 
     shader->set("surfaces[" + std::to_string(NormalId::Right) + "]", (int)part->rightSurface);
     shader->set("surfaces[" + std::to_string(NormalId::Top) + "]", (int)part->topSurface);
@@ -183,11 +184,14 @@ void renderParts() {
     shader->set("numPointLights", 0);
     studsTexture->activate(0);
     shader->set("studs", 0);
+    skyboxTexture->activate(1);
+    shader->set("skybox", 1);
 
     // Pre-calculate the normal matrix for the shader
 
     // Pass in the camera position
     shader->set("viewPos", camera.cameraPos);
+    
 
     // Sort by nearest
     std::map<float, std::shared_ptr<BasePart>> sorted;

--- a/core/src/rendering/skybox.cpp
+++ b/core/src/rendering/skybox.cpp
@@ -22,6 +22,7 @@ Skybox::Skybox(std::array<std::string, 6> faces, unsigned int format) {
 
         glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, format, width, height, 0, format,
                     GL_UNSIGNED_BYTE, data);
+        glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
         stbi_image_free(data);
     }
 
@@ -31,7 +32,7 @@ Skybox::Skybox(std::array<std::string, 6> faces, unsigned int format) {
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
     // Interpolation
-    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 }
 
@@ -41,5 +42,5 @@ Skybox::~Skybox() {
 
 void Skybox::activate(unsigned int textureIdx) {
     glActiveTexture(GL_TEXTURE0 + textureIdx);
-    glBindTexture(GL_TEXTURE_2D, this->ID);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, this->ID);
 }


### PR DESCRIPTION
<img width="949" height="370" alt="image" src="https://github.com/user-attachments/assets/f27a6bee-8c50-46e9-9abc-96feeee2dd74" />

## this adds
- reflectance property that WORKS
- the ability for the brick shader to sample the cubemap
- the ability for cubemap to use mipmaps
- fresnel

## it solves
- the Reflectance property being missing

## what might need to be tested
- does it explode on windows
- does it explode on other linux setups

## how to test
- you can test it by making a build that uses some reflective bricks
- if they look shiny and the computer does not explode that means everything is going well